### PR TITLE
Fix t() returning default language after kirby clone in _setRequestUrl

### DIFF
--- a/class.php
+++ b/class.php
@@ -213,6 +213,7 @@ class StaticSiteGenerator
     $language = $this->_kirby->currentLanguage();
     $this->_kirby = $this->_kirby->clone(['request' => ['url' => $page->url([])]]);
     $this->_kirby->setCurrentLanguage($language?->code() ?? null);
+    $this->_kirby->setCurrentTranslation($language?->code() ?? null);
     return $this->_kirby->page($page->id()) ?: $page;
   }
 


### PR DESCRIPTION
## Problem

When generating a multilingual static site, `t()` always returned strings from the default language (e.g. English) instead of the current page language (e.g. German).

## Root cause

In `_setRequestUrl()`, `$this->_kirby->clone()` creates a fresh Kirby instance to update the request URL. The code then calls `setCurrentLanguage()` on the new instance, but **never calls `setCurrentTranslation()`**.

Since Kirby's `t()` helper resolves strings via the current *translation* (set via `setCurrentTranslation()`), not just the current language, it fell back to the default translation for every page rendered after `_setRequestUrl()` was invoked.

## Fix

Add `setCurrentTranslation()` alongside the existing `setCurrentLanguage()` call on the cloned instance:

```php
$this->_kirby->setCurrentLanguage($language?->code() ?? null);
$this->_kirby->setCurrentTranslation($language?->code() ?? null); // added
```

## Reproduction

1. Set up a Kirby site with 2+ languages (e.g. `en` as default, `de` as secondary)
2. Use `t('some.key')` in a template or block snippet
3. Generate the static site
4. Open the German static pages — they show English translation strings instead of German

🤖 Generated with [Claude Code](https://claude.com/claude-code)